### PR TITLE
Configure custom error pages

### DIFF
--- a/ShareStore/settings.py
+++ b/ShareStore/settings.py
@@ -65,7 +65,7 @@ ROOT_URLCONF = "ShareStore.urls"
 TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
-        "DIRS": [],
+        "DIRS": [os.path.join(BASE_DIR, "templates/drive")],
         "APP_DIRS": True,
         "OPTIONS": {
             "context_processors": [

--- a/ShareStore/urls.py
+++ b/ShareStore/urls.py
@@ -16,6 +16,20 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path, include
+from django.conf.urls import handler403, handler404
+from django.shortcuts import render
+
+
+def custom_403_view(request, exception):
+    return render(request, "drive/403.html", status=403)
+
+
+def custom_404_view(request, exception):
+    return render(request, "drive/404.html", status=404)
+
+
+handler403 = custom_403_view
+handler404 = custom_404_view
 
 urlpatterns = [
     path("admin/", admin.site.urls),


### PR DESCRIPTION
**Description:**
-  Add custom 403 and 404 error handlers to `ShareStore/urls.py`. 
- Adjusted `TEMPLATES` setting to include the custom directory.