### PR TITLE
Fix unnecessary scrolling

### DIFF
--- a/drive/static/drive/styles.css
+++ b/drive/static/drive/styles.css
@@ -5,6 +5,11 @@
     font-family: 'Montserrat', sans-serif;
 }
 
+.navbar,
+.navbar:first-child {
+    background: rgba(0, 0, 0, 0.9);
+}
+
 #share-store {
     font-family: 'Bebas Neue', sans-serif;
     font-size: 1.7rem;
@@ -45,7 +50,7 @@
 }
 
 @media screen and (max-width: 570px) {
-    .sp-width{
+    .sp-width {
         width: 100%;
     }
 }

--- a/drive/templates/drive/403.html
+++ b/drive/templates/drive/403.html
@@ -1,6 +1,6 @@
 {% extends "drive/layout.html" %}
 {% block body %}
-    <div class="container-fluid min-vh-100 d-flex flex-column align-items-center justify-content-center p-3" style="background: black;">
+    <div class="d-flex flex-column align-items-center justify-content-center p-3 flex-grow-1" style="background: black;">
         <h1 class="tagline error">403 | FORBIDDEN</h1>
     </div>
 {% endblock %}

--- a/drive/templates/drive/404.html
+++ b/drive/templates/drive/404.html
@@ -1,6 +1,6 @@
 {% extends "drive/layout.html" %}
 {% block body %}
-    <div class="container-fluid min-vh-100 d-flex flex-column align-items-center justify-content-center p-3" style="background: black;">
+    <div class="d-flex flex-column align-items-center justify-content-center p-3 flex-grow-1" style="background: black;">
         <h1 class="tagline error">404 | NOT FOUND</h1>
     </div>
 {% endblock %}

--- a/drive/templates/drive/file.html
+++ b/drive/templates/drive/file.html
@@ -2,7 +2,7 @@
 {% load static %}
 {% block body %}
     {% if user.is_authenticated %}
-        <div class="container-fluid min-vh-100 d-flex flex-column align-items-center justify-content-center p-3" style="background: black;">
+        <div class="d-flex flex-column align-items-center justify-content-center p-3 flex-grow-1" style="background: black;">
             {% csrf_token %}
             <div>
                 <div class="rounded-3 p-2 text-center mb-2 d-none" id="msg"></div>

--- a/drive/templates/drive/index.html
+++ b/drive/templates/drive/index.html
@@ -2,8 +2,8 @@
 {% load static %}
 {% block body %}
     {% if user.is_authenticated %}
-        <div class="container-fluid min-vh-100 p-0" style="background: black;">
-            <div class="container-fluid p-3">
+        <div class="d-flex flex-grow-1" style="background: black;">
+            <div class="container-fluid p-2">
                 {% if not files %}
                     <div class="alert alert-info" role="alert">
                         No files here! <a href="{% url 'upload' %}" class="alert-link">Upload a FILE</a>.
@@ -35,7 +35,7 @@
                 {% endif %}
             </div>
     {% else %}
-        <div class="container-fluid vh-100 d-flex flex-column align-items-center justify-content-center" style="background: black;">
+        <div class="d-flex flex-column align-items-center justify-content-center flex-grow-1 py-3" style="background: black;">
             <h1 class="tagline">Share Moments, Store Dreams</h1>
             <a href="{% url 'login' %}" class="btn btn-outline-info btn-lg">Login</a>
     {% endif %}

--- a/drive/templates/drive/layout.html
+++ b/drive/templates/drive/layout.html
@@ -23,8 +23,8 @@
         <script src="https://use.fontawesome.com/d1d0840a4c.js"></script>
     </head>
 
-    <body>
-        <nav class="navbar navbar-expand-lg" data-bs-theme="dark" style="background: rgba(0, 0, 0, 0.9);">
+    <body class="container-fluid min-vh-100 min-vw-100 p-0 m-0 d-flex flex-column">
+        <nav class="navbar navbar-expand-lg" data-bs-theme="dark">
             <div class="container-fluid">
                 <a class="navbar-brand d-flex" href="{% url 'index' %}">
                     <img src="{% static 'drive/logo.png' %}" alt="Logo" width="40" height="40" class="d-inline-block align-text-top rounded-circle align-self-center">

--- a/drive/templates/drive/layout.html
+++ b/drive/templates/drive/layout.html
@@ -23,7 +23,7 @@
         <script src="https://use.fontawesome.com/d1d0840a4c.js"></script>
     </head>
 
-    <body class="container-fluid min-vh-100 min-vw-100 p-0 m-0 d-flex flex-column">
+    <body class="container-fluid min-vh-100 p-0 m-0 d-flex flex-column">
         <nav class="navbar navbar-expand-lg" data-bs-theme="dark">
             <div class="container-fluid">
                 <a class="navbar-brand d-flex" href="{% url 'index' %}">

--- a/drive/templates/drive/login.html
+++ b/drive/templates/drive/login.html
@@ -2,8 +2,7 @@
 
 {% load static %}
 {% block body %}
-    <div class="container-fluid min-vh-100 d-flex flex-column align-items-center justify-content-center p-3" style="background: black;">
-
+    <div class="d-flex flex-column align-items-center justify-content-center p-3 flex-grow-1" style="background: black;">
         <div class="container">
             <div class="row justify-content-center">
                 <form action="{% url 'login' %}" method="post" class="bg-dark p-4 rounded-3 col-lg-6 col-md-8 col-sm-10">

--- a/drive/templates/drive/register.html
+++ b/drive/templates/drive/register.html
@@ -2,7 +2,7 @@
 
 {% load static %}
 {% block body %}
-    <div class="container-fluid min-vh-100 d-flex flex-column align-items-center justify-content-center p-3" style="background: black;">
+    <div class="d-flex flex-column align-items-center justify-content-center p-3 flex-grow-1" style="background: black;">
         <div class="container">
             <div class="row justify-content-center">
                 <form action="{% url 'register' %}" method="post" class="bg-dark p-4 rounded-3 col-lg-6 col-md-8 col-sm-10">

--- a/drive/templates/drive/shared.html
+++ b/drive/templates/drive/shared.html
@@ -1,8 +1,8 @@
 {% extends "drive/layout.html" %}
 {% block body %}
     {% if user.is_authenticated %}
-        <div class="container-fluid min-vh-100 p-0" style="background: black;">
-            <div class="container-fluid p-3">
+        <div class="flex-grow-1" style="background: black;">
+            <div class="container-fluid p-2">
                 {% if not shared_files.count %}
                     <div class="alert alert-info" role="alert">
                         You haven't shared any files yet!

--- a/drive/templates/drive/shared_with_me.html
+++ b/drive/templates/drive/shared_with_me.html
@@ -1,8 +1,8 @@
 {% extends "drive/layout.html" %}
 {% block body %}
     {% if user.is_authenticated %}
-        <div class="container-fluid min-vh-100 p-0" style="background: black;">
-            <div class="container-fluid p-3">
+        <div class="flex-grow-1" style="background: black;">
+            <div class="container-fluid p-2">
                 {% if not shared_files.count %}
                     <div class="alert alert-info" role="alert">
                         No files shared with you yet!

--- a/drive/templates/drive/upload.html
+++ b/drive/templates/drive/upload.html
@@ -2,7 +2,7 @@
 
 {% block body %}
     {% if user.is_authenticated %}
-        <div class="container-fluid min-vh-100 d-flex flex-column align-items-center justify-content-center p-3" style="background: black;">
+        <div class="d-flex flex-column align-items-center justify-content-center p-3 flex-grow-1" style="background: black;">
             <form action="{% url 'upload' %}" method="post" enctype="multipart/form-data">
                 {% csrf_token %}
                 {% if error %}


### PR DESCRIPTION
### Description

This PR addresses the issue of unnecessary scrolling caused by applying 100vh to two containers. The layout has been adjusted to use flexbox, ensuring that the inner container takes up the remaining space without causing an unnecessary scrollbar to appear.

### Changes Made

- Remov 100vh from the inner container.
- Apply flexbox to the layout to ensure the inner container takes up the remaining space.

### Related Issues

- Fixes #13