### PR TITLE
Add delete account functionality and fix CSRF token issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ## Description
 Share Store is a web-based file sharing and storage application built using Django and Python for the backend, and JavaScript and Bootstrap for the frontend. It is the final project for CS50's Web Programming with Python and JavaScript. This project contains a single app 'drive'.
 
-Share Store allows users to register, log in, upload files, and manage access permissions for those files. Users can share their files with specific individuals or make them accessible to everyone. Additionally, users can view files shared with them by others. Share Store employs Firebase Storage for file storage and retrieval. It provides features like user authentication, file upload/download, and access control, making it a versatile file-sharing platform.
+Share Store allows users to register, log in, upload files, and manage access permissions for those files. Users can share their files with specific individuals or make them accessible to everyone. Additionally, users can view files shared with them by others. Share Store employs Firebase Storage for file storage and retrieval. It provides features like user authentication, file upload/download, access control, password change, and account deletion, making it a versatile file-sharing platform.
 
 [Project Demo](https://youtu.be/0iN3-Odnxy0?si=5VipCIYMWm4CGpjJ)
 

--- a/drive/static/drive/index.js
+++ b/drive/static/drive/index.js
@@ -1,10 +1,14 @@
 import { removeFile } from "./removeFile.js";
 
-const csrf = document.querySelector('[name=csrfmiddlewaretoken]').value;
+const csrfTokenElement = document.querySelector('[name=csrfmiddlewaretoken]');
 const removeBtns = document.querySelectorAll('.remove-file');
 
-removeBtns.forEach(btn => {
-    btn.addEventListener('click', () => {
-        removeFile(btn.dataset.id, csrf);
+if (removeBtns.length > 0 && csrfTokenElement) {
+    const csrf = csrfTokenElement.value;
+
+    removeBtns.forEach(btn => {
+        btn.addEventListener('click', () => {
+            removeFile(btn.dataset.id, csrf);
+        });
     });
-});
+}

--- a/drive/static/drive/manage_account.js
+++ b/drive/static/drive/manage_account.js
@@ -2,8 +2,6 @@ let tapCount = 0;
 let tapTimeout;
 
 document.getElementById('username-nav').addEventListener('click', () => {
-    console.log('hello', tapCount);
-
     tapCount++;
     clearTimeout(tapTimeout);
     tapTimeout = setTimeout(() => {

--- a/drive/static/drive/manage_account.js
+++ b/drive/static/drive/manage_account.js
@@ -1,0 +1,18 @@
+let tapCount = 0;
+let tapTimeout;
+
+document.getElementById('username-nav').addEventListener('click', () => {
+    console.log('hello', tapCount);
+
+    tapCount++;
+    clearTimeout(tapTimeout);
+    tapTimeout = setTimeout(() => {
+        tapCount = 0;
+    }, 1000); // Reset tap count after 1 second
+
+    if (tapCount === 7) {
+        document.getElementById('deleteAccountForm').style.display = 'block';
+        document.getElementById('changePasswordForm').style.display = 'none';
+        tapCount = 0;
+    }
+});

--- a/drive/static/drive/showPassword.js
+++ b/drive/static/drive/showPassword.js
@@ -1,12 +1,14 @@
-document.querySelector('#showPassword').addEventListener('click', (e) => {
-    const pwdField = document.querySelectorAll('.pwd');
-    if (e.target.checked) {
-        pwdField.forEach(field => {
-            field.type = "text";
-        });
-    } else {
-        pwdField.forEach(field => {
-            field.type = "password";
-        });
-    }
-})
+document.querySelectorAll('.show-password-toggle').forEach(showPwd => {    
+    showPwd.addEventListener('click', (e) => {
+        const pwdField = document.querySelectorAll('.pwd');
+        if (e.target.checked) {
+            pwdField.forEach(field => {
+                field.type = "text";
+            });
+        } else {
+            pwdField.forEach(field => {
+                field.type = "password";
+            });
+        }
+    });
+});

--- a/drive/templates/drive/layout.html
+++ b/drive/templates/drive/layout.html
@@ -67,7 +67,7 @@
                     </ul>
                     {% if user.is_authenticated %}
                         <span class="navbar-text d-flex">
-                            <span class="align-self-center me-2" style="opacity: 0.5;">Signed in as
+                            <span class="align-self-center me-2" id="username-nav" style="opacity: 0.5;">Signed in as
                                 <b>{{ user.username }}</b></span>
                         </span>
                     {% endif %}

--- a/drive/templates/drive/login.html
+++ b/drive/templates/drive/login.html
@@ -20,7 +20,7 @@
                         <input type="password" class="form-control pwd" id="password" name="password" placeholder="Password">
                     </div>
                     <div class="mb-3">
-                        <input type="checkbox" id="showPassword"> Show Password
+                        <input type="checkbox" id="showPassword" class="show-password-toggle"> Show Password
                     </div>
                     <div class="mb-3 d-grid">
                         <input type="submit" value="Login" class="btn btn-outline-light">

--- a/drive/templates/drive/manage_account.html
+++ b/drive/templates/drive/manage_account.html
@@ -5,7 +5,7 @@
     <div class="d-flex flex-column align-items-center justify-content-center p-3 flex-grow-1" style="background: black;">
         <div class="container">
             <div class="row justify-content-center">
-                <form action="{% url 'manage_account' %}" method="post" class="bg-dark p-4 rounded-3 col-lg-6 col-md-8 col-sm-10">
+                <form action="{% url 'manage_account' %}" method="post" class="bg-dark p-4 rounded-3 col-lg-6 col-md-8 col-sm-10" id="changePasswordForm">
                     {% csrf_token %}
                     {% if message %}
                         <div class="bg-danger rounded-3 p-1">
@@ -34,11 +34,34 @@
                         <input type="checkbox" id="showPassword"> Show Password
                     </div>
                     <div class="mb-3 d-grid">
-                        <input type="submit" value="Change Passoword" class="btn btn-outline-light">
+                        <input type="submit" value="Change Password" class="btn btn-outline-light">
+                    </div>
+                </form>
+            </div>
+            <div class="row justify-content-center mt-3">
+                <!-- Hidden Delete Account Form -->
+                <form id="deleteAccountForm" style="display: none;" method="post" action="{% url 'delete_account' %}" class="bg-dark p-4 rounded-3 col-lg-6 col-md-8 col-sm-10">
+                    {% csrf_token %}
+                    <h1 class="text-center my-3">Delete Account</h1>
+                    <div class="mb-3">
+                        <input type="text" class="form-control" id="username" name="username" placeholder="Username" required>
+                    </div>
+                    <div class="mb-3">
+                        <input type="email" class="form-control" id="email" name="email" placeholder="Email" required>
+                    </div>
+                    <div class="mb-3">
+                        <input type="password" class="form-control" id="password" name="password" placeholder="Password" required>
+                    </div>
+                    <div class="mb-3">
+                        <input type="text" class="form-control" id="confirmation_text" name="confirmation_text" placeholder='Type "Delete my account!"' required>
+                    </div>
+                    <div class="mb-3 d-grid">
+                        <button type="submit" class="btn btn-outline-danger">Confirm Delete Account</button>
                     </div>
                 </form>
             </div>
         </div>
     </div>
     <script src="{% static 'drive/showPassword.js' %}"></script>
+    <script src="{% static 'drive/manage_account.js' %}"></script>
 {% endblock %}

--- a/drive/templates/drive/manage_account.html
+++ b/drive/templates/drive/manage_account.html
@@ -31,7 +31,7 @@
                     </div>
                     <div class="mb-3">
                         <label for="showPassword"></label>
-                        <input type="checkbox" id="showPassword"> Show Password
+                        <input type="checkbox" id="showPassword" class="show-password-toggle"> Show Password
                     </div>
                     <div class="mb-3 d-grid">
                         <input type="submit" value="Change Password" class="btn btn-outline-light">
@@ -50,10 +50,15 @@
                         <input type="email" class="form-control" id="email" name="email" placeholder="Email" required>
                     </div>
                     <div class="mb-3">
-                        <input type="password" class="form-control" id="password" name="password" placeholder="Password" required>
+                        <input type="password" class="form-control pwd" id="password" name="password" placeholder="Password" required>
                     </div>
                     <div class="mb-3">
                         <input type="text" class="form-control" id="confirmation_text" name="confirmation_text" placeholder='Type "Delete my account!"' required>
+                        <small><label for="confirmation_text" class="mt-2 text-secondary">Type "Delete my account!"</label></small>
+                    </div>
+                    <div class="mb-3">
+                        <label for="showPasswordDeleteAcc"></label>
+                        <input type="checkbox" id="showPasswordDeleteAcc" class="show-password-toggle"> Show Password
                     </div>
                     <div class="mb-3 d-grid">
                         <button type="submit" class="btn btn-outline-danger">Confirm Delete Account</button>

--- a/drive/templates/drive/register.html
+++ b/drive/templates/drive/register.html
@@ -34,7 +34,7 @@
                     </div>
                     <div class="mb-3">
                         <label for="showPassword"></label>
-                        <input type="checkbox" id="showPassword"> Show Password
+                        <input type="checkbox" id="showPassword" class="show-password-toggle"> Show Password
                     </div>
                     <div class="mb-3 d-grid">
                         <input type="submit" value="Register" class="btn btn-outline-light">

--- a/drive/urls.py
+++ b/drive/urls.py
@@ -14,5 +14,6 @@ urlpatterns = [
     path("file/<int:id>", views.file, name="file"),
     path("permissions/<int:id>", views.manage_access, name="manage_access"),
     path("ping", views.ping, name="ping"),
-    path("manage", views.manage_account, name="manage_account")
+    path("manage", views.manage_account, name="manage_account"),
+    path("delete-account", views.delete_account, name="delete_account"),
 ]


### PR DESCRIPTION
### Summary

This PR adds the delete account functionality and fixes an issue where the CSRF token element was not present on the page when there were no files, causing errors.

### Changes

1. **Delete Account Functionality**:
    - Add a hidden form for account deletion.
    - Implement a tap sequence (7 taps) to reveal the delete account form.
    - Add a confirmation form with fields for username, email, password, and a confirmation text field where the user must type "Delete my account!" exactly.
    - Add the `/delete-account` route to handle account deletion.
    - Update backend logic to handle account deletion.

2. **CSRF Token Issue Fix**:
    - Add a check to ensure the CSRF token is only accessed if it's present (if user has some files).