### PR TITLE
Bump Gunicorn from 22.0.0 to 23.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Django>=4.2.15
 firebase-admin==6.2.0
 python-dotenv==1.0.0
-gunicorn==22.0.0
+gunicorn==23.0.0
 whitenoise==6.6.0
 psycopg2-binary==2.9.9
 dj-database-url==2.1.0


### PR DESCRIPTION
Bump Gunicorn from 22.0.0 to 23.0.0 to prevent Gunicorn HTTP Request/Response Smuggling vulnerability